### PR TITLE
Add explicit "any" return type to Suite constructor

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -11,7 +11,7 @@ declare namespace MochaTypeScript {
         };
         before?: (done?: MochaDone) => void;
         after?: (done?: MochaDone) => void;
-        new();
+        new(): any;
     }
     export interface SuiteTrait {
         (this: Mocha.ISuiteCallbackContext, ctx: Mocha.ISuiteCallbackContext, ctor: Function): void;


### PR DESCRIPTION
I started getting a compile error about an implicit any Suite constructor after doing some upgrades so here is the tiny patch that resolves it.