### PR TITLE
Revert 'use directly the binaries and mocha wrapper' for sake of Windows users

### DIFF
--- a/bin/watch.ts
+++ b/bin/watch.ts
@@ -35,7 +35,7 @@ var argv = yargs
         "m": {
             alias: "mocha",
             demand: false,
-            default: "./node_modules/mocha/bin/mocha",
+            default: "./node_modules/mocha/bin/_mocha",
             describe: "Path to executable mocha, by default points to mocha installed as dev dependency.",
             type: "string"
         },
@@ -95,7 +95,7 @@ function compilationComplete() {
         mocha_options.push("-f");
         mocha_options.push(argv.f);
     }
-    mochap = spawn(argv.mocha, mocha_options);
+    mochap = spawn("node", [argv.mocha].concat(mocha_options));
     let source = mochap;
     mochap.on("close", code => {
         if (source === mochap) {
@@ -120,7 +120,7 @@ function compilationComplete() {
     });
 }
 
-var tscp = spawn(argv.tsc, ["-p", argv.project, "-w"]);
+var tscp = spawn("node", [argv.tsc, "-p", argv.project, "-w"]);
 var tscl = readline.createInterface({ input: tscp.stdout });
 tscl.on("line", line => {
     if (line.indexOf("Compilation complete.") >= 0) {


### PR DESCRIPTION
As I experienced that if we don't revert this change, Windows user can't "watch" because `spawn` on Windows doesn't recognize `mocha` executables.