### PR TITLE
fix #62: also run tests inherited from [abstract] base classes

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@types/chai": "^3.4.35",
     "@types/mocha": "^5.0.0",
-    "@types/node": "^7.0.12",
+    "@types/node": "^7.0.60",
     "assert": "^1.3.0",
     "better-assert": "^1.0.2",
     "chai": "^3.5.0",

--- a/test.ts
+++ b/test.ts
@@ -3,10 +3,7 @@ import { assert } from "chai";
 import { spawnSync } from "child_process";
 import * as path from "path";
 import * as rimraf from "rimraf";
-
-var chai = require("chai");
-var fs = require("fs");
-
+import * as fs from "fs";
 
 function assertContent(actualStr: string, expectedStr: string) {
 
@@ -159,18 +156,12 @@ class SuiteTest {
                                      "--experimentalDecorators", "--module", "commonjs", "--target", target, "--lib",
                                      "es6", path.join("tests", "ts", ts + ".ts")]);
 
-        // console.log(tsc.stdout.toString());
         assert.equal(tsc.stdout.toString(), "", "Expected error free tsc.");
         assert.equal(tsc.status, 0);
 
         let mocha = spawnSync("node", [path.join(".", "node_modules", "mocha", "bin", "_mocha"),
                                        "-C", path.join("tests", "ts", ts + ".js")]);
-        // To debug any actual output while developing:
-        // assert(mocha.status !== 0);
 
-        // console.log(mocha.stderr.toString());
-
-        // To patch the expected use the output of this, but clean up times and callstacks:
         let actual = cleanup(mocha.stdout.toString());
         assertOutput(actual, path.join("tests", "ts", ts + ".expected.txt"));
     }

--- a/test.ts
+++ b/test.ts
@@ -1,4 +1,4 @@
-import { suite, test, slow, timeout, pending, only } from "./index";
+import { suite, test, slow, timeout, skip, pending, only } from "./index";
 import { assert } from "chai";
 import { spawnSync } from "child_process";
 import * as path from "path";
@@ -7,20 +7,72 @@ import * as rimraf from "rimraf";
 var chai = require("chai");
 var fs = require("fs");
 
-function assertOutput(actualStr, expectedStr) {
+
+function assertContent(actualStr: string, expectedStr: string) {
+
     let actual: string[] = actualStr.split("\n");
     let expected: string[] = expectedStr.split("\n");
 
+    assert.equal(actual.length, expected.length, "actual and expected differ in length");
     for(var i = 0; i < expected.length; i++) {
-        if (actual.length <= i) {
-            throw new Error("Actual output is shorter than expected, acutal lines: " + actual.length + ", expected: " + expected.length);
-        }
-        let expectedLine = expected[i].trim();
-        let actualLine = actual[i].trim();
-        if (actualLine.indexOf(expectedLine) === -1) {
-            throw new Error("Unexpected output. Expected: '" + expectedLine + "' to be contained in '" + actualLine + "'");
-        }
+      let expectedLine = expected[i].trim();
+      let actualLine = actual[i].trim();
+      assert.isTrue(actualLine.indexOf(expectedLine) !== -1,
+        "Unexpected output on line '" + i + "'. Expected: '" +
+        expectedLine + "' to be contained in '" + actualLine + "'");
     }
+}
+
+function assertOutput(actual: string, filePath: string) {
+
+    let expected = "";
+    try {
+        expected = fs.readFileSync(filePath, "utf-8");
+        assertContent(cleanup(actual, true), cleanup(expected, true));
+    } catch (e) {
+        console.log("\nerror while testing " + filePath.replace(__dirname, ""));
+        console.log("\n" + e.toString());
+        console.log("\n<<<<< expected\n" + expected);
+        console.log("\n>>>>> actual\n" + cleanup(actual) + "=====");
+        throw e;
+    }
+}
+
+const ELIMINATE_LINE = "__mts_eliminate_line__";
+
+function cleanup(str: string, eliminateAllEmptyLines = false): string {
+
+    // clean up times
+    let result = str.replace(/\s*[(][\d]+[^)]+[)]/g, "");
+    // clean up call stacks
+    result = result.replace(/at\s<.+>.*/g, ELIMINATE_LINE);
+    result = result.replace(/at\s.+[^:]+:[^:]+:[\d]+/g, ELIMINATE_LINE);
+    result = result.replace(/at\s.+[(][^:]+:[^:]+:[^)]+[)]/g, ELIMINATE_LINE);
+    result = result.replace(/at\s.+[\[]as\s+[^\]]+[\]].*/g, ELIMINATE_LINE);
+    // clean up calls
+    result = result.replace(/>\s.+/g, ELIMINATE_LINE);
+
+    return trimEmptyLines(result, eliminateAllEmptyLines);
+}
+
+function trimEmptyLines(str: string, eliminateAll = false): string {
+
+    const collected: string[] = [];
+    const lines = str.split('\n');
+    let emptyLinesCount = 0;
+    for (const line of lines) {
+        if (line === "" || line.match(/^\s*$/) || line.indexOf(ELIMINATE_LINE) !== -1) {
+            emptyLinesCount++;
+            continue;
+        }
+        if (emptyLinesCount && !eliminateAll) {
+            collected.push('');
+        }
+        emptyLinesCount = 0;
+        collected.push(line);
+    }
+
+    return collected.join('\n');
 }
 
 @suite("typescript", slow(5000), timeout(15000))
@@ -86,26 +138,41 @@ class SuiteTest {
         this.run("es6", "context.suite");
     }
 
+    @test "abstract inheritance suite es5"() {
+        this.run("es5", "abstract.inheritance.suite");
+    }
+
+    @test "abstract inheritance suite es6"() {
+        this.run("es6", "abstract.inheritance.suite");
+    }
+
+    @test "suite inheritance suite es5"() {
+        this.run("es5", "suite.inheritance.suite");
+    }
+
+    @test "suite inheritance suite es6"() {
+        this.run("es6", "suite.inheritance.suite");
+    }
+
     private run(target: string, ts: string) {
-        let tsc = spawnSync("node", ["./node_modules/typescript/bin/tsc", "--experimentalDecorators", "--module", "commonjs", "--target", target, "--lib", "es6", "tests/ts/" + ts + ".ts"]);
+        let tsc = spawnSync("node", [path.join(".", "node_modules", "typescript", "bin", "tsc"),
+                                     "--experimentalDecorators", "--module", "commonjs", "--target", target, "--lib",
+                                     "es6", path.join("tests", "ts", ts + ".ts")]);
 
         // console.log(tsc.stdout.toString());
         assert.equal(tsc.stdout.toString(), "", "Expected error free tsc.");
         assert.equal(tsc.status, 0);
 
-        let mocha = spawnSync("node", ["./node_modules/mocha/bin/_mocha", "tests/ts/" + ts + ".js"]);
+        let mocha = spawnSync("node", [path.join(".", "node_modules", "mocha", "bin", "_mocha"),
+                                       "-C", path.join("tests", "ts", ts + ".js")]);
         // To debug any actual output while developing:
         // assert(mocha.status !== 0);
 
         // console.log(mocha.stderr.toString());
 
-        let actual = mocha.stdout.toString();
-        let expected = fs.readFileSync("./tests/ts/" + ts + ".expected.txt", "utf-8");
-
         // To patch the expected use the output of this, but clean up times and callstacks:
-        // console.log("=====\n" + actual + "\n=====");
-
-        assertOutput(actual, expected);
+        let actual = cleanup(mocha.stdout.toString());
+        assertOutput(actual, path.join("tests", "ts", ts + ".expected.txt"));
     }
 }
 
@@ -146,42 +213,31 @@ class PackageTest {
         assert.equal(pack.stderr.toString(), "");
         assert.equal(pack.status, 0, "npm pack failed.");
         const lines = (<string>pack.stdout.toString()).split("\n").filter(line => !!line);
-        assert.isAtLeast(lines.length, 1, "Expected atleast one line of output from npm pack with the .tgz name.");
+        assert.isAtLeast(lines.length, 1,
+          "Expected atleast one line of output from npm pack with the .tgz name.");
         PackageTest.tgzPath = path.resolve(lines[lines.length - 1]);
     }
 
     private testPackage(packageName: string, installTypesMocha: boolean = false): void {
         let cwd;
         let npmtest;
-        let actual;
-        try {
-            cwd = path.resolve("tests/repo", packageName);
-            rimraf.sync(path.join(cwd, "node_modules"));
+        cwd = path.resolve(path.join("tests", "repo"), packageName);
+        rimraf.sync(path.join(cwd, "node_modules"));
 
-            let npmi = spawnSync("npm", ["i", "--no-package-lock"], { cwd });
-            assert.equal(npmi.status, 0, "'npm i' failed.");
+        let npmi = spawnSync("npm", ["i", "--no-package-lock"], { cwd });
+        assert.equal(npmi.status, 0, "'npm i' failed.");
 
-            let args: string[];
-            if (installTypesMocha) {
-                args = ["i", PackageTest.tgzPath, "@types/mocha", "--no-save", "--no-package-lock"];
-            } else {
-                args = ["i", PackageTest.tgzPath, "--no-save", "--no-package-lock"];
-            }
-
-            let npmitgz = spawnSync("npm", args, { cwd });
-            assert.equal(npmitgz.status, 0, "'npm i <tgz>' failed.");
-
-            npmtest = spawnSync("npm", ["test"], { cwd });
-            actual = npmtest.stdout.toString();
-
-            let expected = fs.readFileSync(cwd + "/expected.txt", "utf-8");
-            assertOutput(actual, expected);
-        } catch(e) {
-            try {
-                console.log("=====\n" + actual + "\n=====");
-                console.log(npmtest.stderr.toString());
-            } catch(ee) {}
-            throw e;
+        let args: string[];
+        if (installTypesMocha) {
+            args = ["i", PackageTest.tgzPath, "@types/mocha", "--no-save", "--no-package-lock"];
+        } else {
+            args = ["i", PackageTest.tgzPath, "--no-save", "--no-package-lock"];
         }
+
+        let npmitgz = spawnSync("npm", args, { cwd });
+        assert.equal(npmitgz.status, 0, "'npm i <tgz>' failed.");
+
+        npmtest = spawnSync("npm", ["test"], { cwd });
+        assertOutput(npmtest.stdout.toString(), path.join(cwd, "expected.txt"));
     }
 }

--- a/tests/repo/custom-ui/expected.txt
+++ b/tests/repo/custom-ui/expected.txt
@@ -1,9 +1,4 @@
 
-> custom-ui@1.0.0 test
-> tsc && mocha
-
-
-
   Suite1
     ✓ one
     1) two
@@ -41,7 +36,7 @@
     6) testFailing
     ✓ beforeAfterCalled
 
-  InstanceTests
+  AsyncInstanceTests
     ✓ test
     7) testFailing
     ✓ beforeAfterCalled
@@ -56,7 +51,56 @@
     9) tryToGetPass4
     ✓ overrideSuiteRetries
 
-
   17 passing
   4 pending
   9 failing
+
+  1) Suite1
+       two:
+     Error: instant fail
+
+  2) Suite1
+       four:
+     Error: async fail
+
+  3) TimoutSuite
+       slow:
+     Error: Timeout of 10ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.
+
+  4) TimeoutSuite2
+       slow:
+     Error: Timeout of 20ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.
+
+  5) SequenceOne
+       two:
+     Error: Fail!
+
+  6) InstanceTests
+       testFailing:
+
+      AssertionError: expected false to be true
+      + expected - actual
+
+      -false
+      +true
+
+  7) AsyncInstanceTests
+       testFailing:
+
+      AssertionError: expected false to be true
+      + expected - actual
+
+      -false
+      +true
+
+  8) FlakyMethodDecorator
+       tryOnce:
+
+      AssertionError: expected 2 to be above 2
+      + expected - actual
+
+  9) FlakySuiteDecorator
+       tryToGetPass4:
+
+      AssertionError: expected 4 to be above 4
+      + expected - actual

--- a/tests/repo/module-usage/expected.txt
+++ b/tests/repo/module-usage/expected.txt
@@ -1,9 +1,4 @@
 
-> module-usage@1.0.0 test
-> tsc && mocha
-
-
-
   Suite1
     ✓ one
     1) two
@@ -36,7 +31,26 @@
   named
     ✓ with name
 
-
   9 passing
   4 pending
   5 failing
+
+  1) Suite1
+       two:
+     Error: instant fail
+
+  2) Suite1
+       four:
+     Error: async fail
+
+  3) TimoutSuite
+       slow:
+     Error: Timeout of 10ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.
+
+  4) TimeoutSuite2
+       slow:
+     Error: Timeout of 20ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.
+
+  5) SequenceOne
+       two:
+     Error: Fail!

--- a/tests/repo/setting-up/expected.txt
+++ b/tests/repo/setting-up/expected.txt
@@ -1,11 +1,5 @@
 
-> setting-up@1.0.0 test
-> tsc && mocha
-
-
-
   Hello
     ✓ world
-
 
   1 passing

--- a/tests/ts/abstract.inheritance.suite.expected.txt
+++ b/tests/ts/abstract.inheritance.suite.expected.txt
@@ -1,0 +1,6 @@
+
+  ConcreteTest
+    ✓ test from ConcreteTest
+    ✓ inherited test from AbstractTestBase
+
+  2 passing

--- a/tests/ts/abstract.inheritance.suite.ts
+++ b/tests/ts/abstract.inheritance.suite.ts
@@ -1,0 +1,27 @@
+import { suite, test } from "../../index";
+import { assert } from "chai";
+
+abstract class AbstractTestBase {
+
+  protected _truthyValue: boolean;
+
+  @test "inherited test from AbstractTestBase"() {
+
+    assert.isTrue(this._truthyValue, "truthyValue should have been true");
+  }
+}
+
+@suite class ConcreteTest extends AbstractTestBase {
+
+  private _falsyValue = false;
+
+  before(): void {
+
+    this._truthyValue = true;
+  }
+
+  @test "test from ConcreteTest"() {
+
+    assert.isFalse(this._falsyValue, "falsyValue should have been false");
+  }
+}

--- a/tests/ts/context.suite.expected.txt
+++ b/tests/ts/context.suite.expected.txt
@@ -1,5 +1,4 @@
 
-
   Static
     ✓ one
 
@@ -29,6 +28,5 @@ End of test: OAuth npmjs Exchange token for oauth session
     ✓ Request sensitive data
 End of test: OAuth npmjs Request sensitive data
 End of test: true
-
 
   10 passing

--- a/tests/ts/only.suite.expected.txt
+++ b/tests/ts/only.suite.expected.txt
@@ -1,7 +1,5 @@
 
-
   Suite1
     ✓ test1
-
 
   1 passing

--- a/tests/ts/only.v2.suite.expected.txt
+++ b/tests/ts/only.v2.suite.expected.txt
@@ -1,5 +1,4 @@
 
-
   Suite1
     ✓ test
 
@@ -11,6 +10,5 @@
 
   Suite4
     ✓ test
-
 
   4 passing

--- a/tests/ts/pending.suite.expected.txt
+++ b/tests/ts/pending.suite.expected.txt
@@ -1,11 +1,9 @@
 
-
   Suite1
     - test1
 
   Suite2
     ✓ test1
-
 
   1 passing
   1 pending

--- a/tests/ts/pending.v2.suite.expected.txt
+++ b/tests/ts/pending.v2.suite.expected.txt
@@ -1,5 +1,4 @@
 
-
   Pending1
     - test1
 
@@ -20,7 +19,6 @@
 
   Suite2
     ✓ test1
-
 
   1 passing
   6 pending

--- a/tests/ts/retries.suite.expected.txt
+++ b/tests/ts/retries.suite.expected.txt
@@ -1,5 +1,4 @@
 
-
   FlakyMethodDecorator
     1) tryOnce
     ✓ tryTwice
@@ -10,6 +9,13 @@
     2) tryToGetPass4
     ✓ overrideSuiteRetries
 
-
   4 passing
   2 failing
+
+  1) FlakyMethodDecorator
+       tryOnce:
+     AssertionError: expected 2 to be above 2
+
+  2) FlakySuiteDecorator
+       tryToGetPass4:
+     AssertionError: expected 4 to be above 4

--- a/tests/ts/suite.inheritance.suite.expected.txt
+++ b/tests/ts/suite.inheritance.suite.expected.txt
@@ -1,0 +1,9 @@
+
+  PartialTest
+    ✓ test from PartialTest
+
+  CompleteTest
+    ✓ test from CompleteTest
+    ✓ test from PartialTest
+
+  3 passing

--- a/tests/ts/suite.inheritance.suite.ts
+++ b/tests/ts/suite.inheritance.suite.ts
@@ -1,0 +1,34 @@
+import { suite, test } from "../../index";
+import { assert } from "chai";
+
+@suite class PartialTest {
+
+  protected _truthyValue: boolean;
+
+  before() {
+
+    this._truthyValue = true;
+  }
+
+  @test "test from PartialTest"() {
+
+    assert.isTrue(this._truthyValue, "truthyValue should have been true");
+  }
+}
+
+@suite class CompleteTest extends PartialTest {
+
+  private _falsyValue = true;
+
+  before(): void {
+
+    super.before();
+
+    this._falsyValue = false;
+  }
+
+  @test "test from CompleteTest"() {
+
+    assert.isFalse(this._falsyValue, "falsyValue should have been false");
+  }
+}

--- a/tests/ts/test.suite.expected.txt
+++ b/tests/ts/test.suite.expected.txt
@@ -1,5 +1,4 @@
 
-
   mocha typescript
     ✓ should pass when asserts are fine
     1) should fail when asserts are broken
@@ -81,7 +80,47 @@
     TestClass
       ✓ method
 
-
   25 passing
   2 pending
   9 failing
+
+  1) mocha typescript
+       should fail when asserts are broken:
+
+      Error: Assert failed
+      + expected - actual
+
+      -to fail
+      +expected
+
+  2) mocha typescript
+       should fail async when given error:
+     Error: Oops...
+
+  3) mocha typescript
+       should fail when promise rejected:
+     Error: Ooopsss...
+
+  4) FailingAsyncLifeCycle
+       "after each" hook for "one":
+     Error: Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.
+
+  5) FailingAsyncLifeCycle
+       "after all" hook:
+     Error: Promise rejected with no or falsy reason
+
+  6) Times
+       when slower than timeout fails:
+     Error: Timeout of 10ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.
+
+  7) OverallSlow
+       second slow:
+     Error: Timeout of 10ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.
+
+  8) SlowBefore
+       "before each" hook for "will fail for slow before":
+     Error: Timeout of 10ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.
+
+  9) SlowAfter
+       "after each" hook for "will fail for slow after":
+     Error: Timeout of 10ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.

--- a/tests/ts/test.v2.suite.expected.txt
+++ b/tests/ts/test.v2.suite.expected.txt
@@ -1,5 +1,4 @@
 
-
   vanila tdd suite
     ✓ vanila test
     1) vanila failing test
@@ -45,7 +44,7 @@
 
   Slows
     ✓ pass1
-    ✓ pass2 (
+    ✓ pass2
     ✓ pass3
 
   mocha typescript
@@ -56,8 +55,8 @@
     - test skip
     10) test intentinally timeout
     11) test intentinall fail due error before timeout
-    ✓ test won't timeout but will be redish slow (
-    ✓ test won't timeout but will be yellowish slow (
+    ✓ test won't timeout but will be redish slow
+    ✓ test won't timeout but will be yellowish slow
 
   Skipped1
     - test
@@ -87,8 +86,58 @@
     13) testFailing
     ✓ beforeAfterCalled
 
-
   24 passing
   14 pending
   13 failing
 
+  1) vanila tdd suite
+       vanila failing test:
+     Error: x
+
+  2) vanila bdd suite
+       vanila failing test:
+     Error: x
+
+  3) Timeouts
+       pass2:
+     Error: Timeout of 10ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.
+
+  4) InlineTrait
+       timeout:
+     Error: Timeout of 10ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.
+
+  5) StockSequence
+       step2:
+     Error: Failed
+
+  6) CustomSequence
+       step2:
+     Error: Failed
+
+  7) name and trait
+       step2:
+     Error: Failed
+
+  8) mocha typescript
+       test fail:
+     Error: Fail intentionally!
+
+  9) mocha typescript
+       test fail 2:
+     Error: Fail intentionally!
+
+  10) mocha typescript
+       test intentinally timeout:
+     Error: Timeout of 5ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.
+
+  11) mocha typescript
+       test intentinall fail due error before timeout:
+     Error: done() invoked with non-Error: Ooopsss...
+
+  12) InstanceTests
+       testFailing:
+     AssertionError: expected false to be true
+
+  13) AsyncInstanceTests
+       testFailing:
+     AssertionError: expected false to be true


### PR DESCRIPTION
TODO

- [x] implement feature
- [x] implement tests
- [x] fix tests that fail due to local path  #issues
- [x] fix tests that fail due to a mismatch of empty lines in the expected vs. actual on ts5/ts6 resulting from stack trace elimination
- [x] FUTURE: requires further investigation into mocha's hierarchical contexts and before/after actions

~existing failing tests are unrelated and caused by duplicate declarations in the typescript .d.ts files by both ``@types/mocha`` and mocha-typescript. There is an issue and a PR for this, see #61 and #64.~