### PR TITLE
fix #61

### DIFF
--- a/globals.d.ts
+++ b/globals.d.ts
@@ -48,12 +48,6 @@ declare namespace Mocha {
     }
 }
 
-declare var suite: Mocha.IContextDefinition;
-declare var test: Mocha.ITestDefinition;
-
-declare var describe: Mocha.IContextDefinition;
-declare var it: Mocha.ITestDefinition;
-
 declare var skipOnError: MochaTypeScript.SuiteTrait;
 
 declare function slow(time: number): PropertyDecorator & ClassDecorator & MochaTypeScript.SuiteTrait & MochaTypeScript.TestTrait;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,19 +1,10 @@
 declare namespace Mocha {
-    export interface IContextDefinition {}
-    export interface ITestDefinition {}
-    export interface ISuiteCallbackContext {}
-    export interface ITestCallbackContext {}
-
     export interface ITest {
         <T>(target: Object, propertyKey: string | symbol, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T> | void;
     }
     export interface ISuite {
         <TFunction extends Function>(target: TFunction): TFunction | void;
     }
-}
-
-interface MochaDone {
-    (error?: any): any;
 }
 
 declare namespace MochaTypeScript {

--- a/index.ts
+++ b/index.ts
@@ -74,12 +74,12 @@ function applyDecorators(mocha: Mocha.IHookCallbackContext | Mocha.ISuiteCallbac
 		mocha.timeout(timeoutValue);
 	}
 	const slowValue = method[slowSymbol];
-	if (typeof slowValue === "number") {
-		mocha.slow(slowValue);
+	if (mocha['slow'] && typeof slowValue === "number") {
+		mocha['slow'](slowValue);
 	}
 	const retriesValue = method[retriesSymbol];
-	if (typeof retriesValue === "number") {
-		mocha.retries(retriesValue);
+	if (mocha['retries'] && typeof retriesValue === "number") {
+		mocha['retries'](retriesValue);
 	}
 	const contextProperty = ctorOrProto[contextSymbol];
 	if (contextProperty) {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "devDependencies": {
     "@types/chai": "^3.4.35",
+    "@types/mocha": "^5.0.0",
     "@types/node": "^7.0.12",
     "assert": "^1.3.0",
     "better-assert": "^1.0.2",


### PR DESCRIPTION
- also add @types/mocha as dev dependency so that future changes to these declarations will trigger failures early
- reworked the way that the slow and retries decorators are called to resolve compile time issues with IHookCallbackContext