### PR TITLE
fix #74 failing tests due to change in behaviour of npm pack

### DIFF
--- a/test.ts
+++ b/test.ts
@@ -200,7 +200,7 @@ class PackageTest {
 
     @timeout(30000)
     static before() {
-        let pack = spawnSync("npm", ["pack"]);
+        let pack = spawnSync("npm", ["pack", "--quiet"]);
         assert.equal(pack.stderr.toString(), "");
         assert.equal(pack.status, 0, "npm pack failed.");
         const lines = (<string>pack.stdout.toString()).split("\n").filter(line => !!line);


### PR DESCRIPTION
intermediate solution is to run npm pack with the --quiet option
bug report has been filed over at https://github.com/npm/npm/issues/20806