### PR TITLE
add `useContainer` to integrate DI container

### DIFF
--- a/di/typedi.ts
+++ b/di/typedi.ts
@@ -1,6 +1,6 @@
 import "reflect-metadata";
-import { Container } from 'typedi';
-import { register } from '../index';
+import { Container } from "typedi";
+import { register } from "../index";
 
 register({
     handles: () => true,

--- a/di/typedi.ts
+++ b/di/typedi.ts
@@ -1,0 +1,8 @@
+import "reflect-metadata";
+import { Container } from 'typedi';
+import { register } from '../index';
+
+register({
+    handles: () => true,
+    create: (cls) => Container.get(cls),
+});

--- a/index.d.ts
+++ b/index.d.ts
@@ -70,6 +70,16 @@ declare namespace MochaTypeScript {
         skip(name: string, ... traits: MochaTypeScript.TestTrait[]): PropertyDecorator;
         skip(... traits: MochaTypeScript.TestTrait[]): PropertyDecorator;
     }
+
+    export interface TestClass<T> {
+        new(...args: any[]): T;
+        prototype: T;
+    }
+
+    export interface DependencyInjectionSystem {
+        handles<T>(cls: TestClass<T>): boolean;
+        create<T>(cls: TestClass<T>): typeof cls.prototype;
+    }
 }
 
 declare module "mocha-typescript" {
@@ -91,8 +101,5 @@ declare module "mocha-typescript" {
 
     export const skipOnError: MochaTypeScript.SuiteTrait;
 
-    export interface Container {
-        get(klass: any): any
-    }
-    export function useContainer(container: Container): void;
+    export function register(instantiator: MochaTypeScript.DependencyInjectionSystem): boolean;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -90,4 +90,9 @@ declare module "mocha-typescript" {
     export function context(target: Object, propertyKey: string | symbol): void;
 
     export const skipOnError: MochaTypeScript.SuiteTrait;
+
+    export interface Container {
+        get(klass: any): any
+    }
+    export function useContainer(container: Container): void;
 }

--- a/index.ts
+++ b/index.ts
@@ -136,20 +136,20 @@ function suiteClassCallback(target: SuiteCtor, context: TestFunctions) {
         if (prototype.before) {
             if (prototype.before.length > 0) {
                 beforeEachFunction = noname(function(this: Mocha.IHookCallbackContext, done: Function) {
-                    instance = new target();
+                    instance = getInstance(target);
                     applyDecorators(this, prototype, prototype.before, instance);
                     return prototype.before.call(instance, done);
                 });
             } else {
                 beforeEachFunction = noname(function(this: Mocha.IHookCallbackContext) {
-                    instance = new target();
+                    instance = getInstance(target);
                     applyDecorators(this, prototype, prototype.before, instance);
                     return prototype.before.call(instance);
                 });
             }
         } else {
             beforeEachFunction = noname(function(this: Mocha.IHookCallbackContext) {
-                instance = new target();
+                instance = getInstance(target);
             });
         }
         context.beforeEach(beforeEachFunction);
@@ -669,5 +669,17 @@ function tsdd(suite) {
         context.skipOnError = skipOnError;
     });
 }
+
+let userContainer:Container;
+
+export interface Container {
+	get(klass: any): any
+}
+export function useContainer(container: Container) {
+	userContainer = container;
+}
+
+const getInstance = (klass:any) => userContainer ? userContainer.get(klass) : new klass();
+
 module.exports = Object.assign(tsdd, exports);
 (Mocha as any).interfaces["mocha-typescript"] = tsdd;

--- a/index.ts
+++ b/index.ts
@@ -684,24 +684,24 @@ const defaultDependencyInjectionSystem: DependencyInjectionSystem = {
     handles() { return true; },
     create<T>(cls: TestClass<T>) {
         return new cls();
-    }
-}
+    },
+};
 
 const dependencyInjectionSystems: DependencyInjectionSystem[] = [defaultDependencyInjectionSystem];
 
 function getInstance<T>(testClass: TestClass<T>) {
-	const di = dependencyInjectionSystems.find(di => di.handles(testClass));
-	return di.create(testClass);
+    const di = dependencyInjectionSystems.find((di) => di.handles(testClass));
+    return di.create(testClass);
 }
 
 /**
  * Register a dependency injection system.
  */
 export function register(instantiator: DependencyInjectionSystem) {
-	// Maybe check if it is not already added?
-	if (dependencyInjectionSystems.some(di => di === instantiator)) { return false };
-	dependencyInjectionSystems.unshift(instantiator);
-	return true;
+    // Maybe check if it is not already added?
+    if (dependencyInjectionSystems.some((di) => di === instantiator)) { return false; }
+    dependencyInjectionSystems.unshift(instantiator);
+    return true;
 }
 
 module.exports = Object.assign(tsdd, exports);

--- a/package.json
+++ b/package.json
@@ -39,9 +39,11 @@
     "better-assert": "^1.0.2",
     "chai": "^3.5.0",
     "mocha": "^5.2.0",
+    "reflect-metadata": "^0.1.12",
     "rimraf": "^2.6.1",
     "source-map-support": "^0.4.15",
     "tslint": "^5.10.0",
+    "typedi": "^0.7.3",
     "typescript": "^2.4.1"
   },
   "files": [

--- a/test.ts
+++ b/test.ts
@@ -121,11 +121,14 @@ class SuiteTest {
     @params({ target: "es6", ts: "params.only.suite" })
     @params({ target: "es5", ts: "params.naming.suite" })
     @params({ target: "es6", ts: "params.naming.suite" })
+    @params({ target: "es5", ts: "di.typedi.suite" })
+    @params({ target: "es6", ts: "di.typedi.suite" })
+
     @params.naming(({ target, ts }) => `${ts} ${target}`)
     public run({ target, ts }) {
         const tsc = spawnSync("node", [path.join(".", "node_modules", "typescript", "bin", "tsc"),
-            "--experimentalDecorators", "--module", "commonjs", "--target", target, "--lib",
-            "es6", path.join("tests", "ts", ts + ".ts")]);
+            "--emitDecoratorMetadata", "--experimentalDecorators", "--module", "commonjs",
+            "--target", target, "--lib", "es6", path.join("tests", "ts", ts + ".ts")]);
 
         assert.equal(tsc.stdout.toString(), "", "Expected error free tsc.");
         assert.equal(tsc.status, 0);

--- a/tests/ts/di.typedi.suite.expected.txt
+++ b/tests/ts/di.typedi.suite.expected.txt
@@ -1,0 +1,5 @@
+
+  TypeDITest
+    ✓ test linear function
+
+  1 passing

--- a/tests/ts/di.typedi.suite.ts
+++ b/tests/ts/di.typedi.suite.ts
@@ -1,7 +1,7 @@
-import { suite, test, register } from "../../index";
 import { assert } from "chai";
 import { Service } from "typedi";
 import "../../di/typedi";
+import { register, suite, test } from "../../index";
 
 @Service()
 class Add {
@@ -27,8 +27,10 @@ class Linear {
 
 @suite class TypeDITest {
   constructor(public liner: Linear) { }
-  @test "test linear function"() {
-    const k = 123, x = 63, b = 235;
+  @test public "test linear function"() {
+    const k = 123;
+    const x = 63;
+    const b = 235;
     assert.equal(this.liner.do(k, x, b), k * x + b,
       `this.liner.do(${k}, ${x}, ${b}) should equal ${k} * ${x} + ${b}`);
   }

--- a/tests/ts/di.typedi.suite.ts
+++ b/tests/ts/di.typedi.suite.ts
@@ -1,0 +1,35 @@
+import { suite, test, register } from "../../index";
+import { assert } from "chai";
+import { Service } from "typedi";
+import "../../di/typedi";
+
+@Service()
+class Add {
+  public do(a: number, b: number) {
+    return a + b;
+  }
+}
+
+@Service()
+class Mul {
+  public do(a: number, b: number) {
+    return a * b;
+  }
+}
+
+@Service()
+class Linear {
+  constructor(private add: Add, private mul: Mul) { }
+  public do(k: number, x: number, b: number) {
+    return this.add.do(this.mul.do(k, x), b);
+  }
+}
+
+@suite class TypeDITest {
+  constructor(public liner: Linear) { }
+  @test "test linear function"() {
+    const k = 123, x = 63, b = 235;
+    assert.equal(this.liner.do(k, x, b), k * x + b,
+      `this.liner.do(${k}, ${x}, ${b}) should equal ${k} * ${x} + ${b}`);
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
         "removeComments": false,
         "preserveConstEnums": true,
         "sourceMap": true,
+        "emitDecoratorMetadata": true,
         "experimentalDecorators": true,
         "declaration": false,
         "listFiles": false


### PR DESCRIPTION
new feature:
```typescript
import { useContainer } from 'mocha-typescript';
import { Container } from 'typedi';
useContainer(Container);
```
It will get instance of suite class from a container instead of `new`.
