### PR TITLE
feat: support for custom DI, support for typedi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+<a name="1.1.16"></a>
+## [1.1.16](https://github.com/PanayotCankov/mocha-typescript/compare/v1.1.15...v1.1.16) (2018-06-10)
+
+
+### Features
+
+* support for custom DI, support for typedi ([7dfa470](https://github.com/PanayotCankov/mocha-typescript/commit/7dfa470))
+
+
+

--- a/di/typedi.ts
+++ b/di/typedi.ts
@@ -1,0 +1,8 @@
+import "reflect-metadata";
+import { Container } from "typedi";
+import { registerDI } from "../index";
+
+registerDI({
+    handles: () => true,
+    create: (cls) => Container.get(cls),
+});

--- a/index.d.ts
+++ b/index.d.ts
@@ -70,6 +70,16 @@ declare namespace MochaTypeScript {
         skip(name: string, ... traits: MochaTypeScript.TestTrait[]): PropertyDecorator;
         skip(... traits: MochaTypeScript.TestTrait[]): PropertyDecorator;
     }
+
+    export interface TestClass<T> {
+        new(...args: any[]): T;
+        prototype: T;
+    }
+
+    export interface DependencyInjectionSystem {
+        handles<T>(cls: TestClass<T>): boolean;
+        create<T>(cls: TestClass<T>): typeof cls.prototype;
+    }
 }
 
 declare module "mocha-typescript" {
@@ -90,4 +100,6 @@ declare module "mocha-typescript" {
     export function context(target: Object, propertyKey: string | symbol): void;
 
     export const skipOnError: MochaTypeScript.SuiteTrait;
+
+    export function registerDI(instantiator: MochaTypeScript.DependencyInjectionSystem): boolean;
 }

--- a/index.ts
+++ b/index.ts
@@ -137,20 +137,20 @@ function suiteClassCallback(target: SuiteCtor, context: TestFunctions) {
         if (prototype.before) {
             if (prototype.before.length > 0) {
                 beforeEachFunction = noname(function(this: Mocha.IHookCallbackContext, done: Function) {
-                    instance = new target();
+                    instance = getInstance(target);
                     applyDecorators(this, prototype, prototype.before, instance);
                     return prototype.before.call(instance, done);
                 });
             } else {
                 beforeEachFunction = noname(function(this: Mocha.IHookCallbackContext) {
-                    instance = new target();
+                    instance = getInstance(target);
                     applyDecorators(this, prototype, prototype.before, instance);
                     return prototype.before.call(instance);
                 });
             }
         } else {
             beforeEachFunction = noname(function(this: Mocha.IHookCallbackContext) {
-                instance = new target();
+                instance = getInstance(target);
             });
         }
         context.beforeEach(beforeEachFunction);
@@ -676,5 +676,40 @@ function tsdd(suite) {
         context.skipOnError = skipOnError;
     });
 }
+
+interface TestClass<T> {
+    new(...args: any[]): T;
+    prototype: T;
+}
+
+interface DependencyInjectionSystem {
+    handles<T>(cls: TestClass<T>): boolean;
+    create<T>(cls: TestClass<T>): typeof cls.prototype;
+}
+
+const defaultDependencyInjectionSystem: DependencyInjectionSystem = {
+    handles() { return true; },
+    create<T>(cls: TestClass<T>) {
+        return new cls();
+    },
+};
+
+const dependencyInjectionSystems: DependencyInjectionSystem[] = [defaultDependencyInjectionSystem];
+
+function getInstance<T>(testClass: TestClass<T>) {
+    const di = dependencyInjectionSystems.find((di) => di.handles(testClass));
+    return di.create(testClass);
+}
+
+/**
+ * Register a dependency injection system.
+ */
+export function registerDI(instantiator: DependencyInjectionSystem) {
+    // Maybe check if it is not already added?
+    if (dependencyInjectionSystems.some((di) => di === instantiator)) { return false; }
+    dependencyInjectionSystems.unshift(instantiator);
+    return true;
+}
+
 module.exports = Object.assign(tsdd, exports);
 (Mocha as any).interfaces["mocha-typescript"] = tsdd;

--- a/package.json
+++ b/package.json
@@ -43,7 +43,9 @@
     "rimraf": "^2.6.2",
     "source-map-support": "^0.5.6",
     "tslint": "^5.10.0",
-    "typescript": "^2.9.1"
+    "typescript": "^2.9.1",
+    "reflect-metadata": "^0.1.12",
+    "typedi": "^0.7.3"
   },
   "files": [
     "index.js",

--- a/test.ts
+++ b/test.ts
@@ -118,11 +118,14 @@ class SuiteTest {
     @params({ target: "es6", ts: "params.only.suite" })
     @params({ target: "es5", ts: "params.naming.suite" })
     @params({ target: "es6", ts: "params.naming.suite" })
+    @params({ target: "es5", ts: "di.typedi.suite" })
+    @params({ target: "es6", ts: "di.typedi.suite" })
+
     @params.naming(({ target, ts }) => `${ts} ${target}`)
     public run({ target, ts, expectError = false }) {
         const tsc = spawnSync("node", [path.join(".", "node_modules", "typescript", "bin", "tsc"),
-            "--experimentalDecorators", "--module", "commonjs", "--target", target, "--lib",
-            "es6", path.join("tests", "ts", ts + ".ts")]);
+            "--emitDecoratorMetadata", "--experimentalDecorators", "--module", "commonjs",
+            "--target", target, "--lib", "es6", path.join("tests", "ts", ts + ".ts")]);
 
         assert.equal(tsc.stdout.toString(), "", "Expected error free tsc.");
         assert.equal(tsc.status, 0);

--- a/tests/ts/di.typedi.suite.expected.txt
+++ b/tests/ts/di.typedi.suite.expected.txt
@@ -1,0 +1,5 @@
+
+  TypeDITest
+    ✓ test linear function
+
+  1 passing

--- a/tests/ts/di.typedi.suite.ts
+++ b/tests/ts/di.typedi.suite.ts
@@ -1,0 +1,37 @@
+import { assert } from "chai";
+import { Service } from "typedi";
+import "../../di/typedi";
+import { suite, test } from "../../index";
+
+@Service()
+class Add {
+  public do(a: number, b: number) {
+    return a + b;
+  }
+}
+
+@Service()
+class Mul {
+  public do(a: number, b: number) {
+    return a * b;
+  }
+}
+
+@Service()
+class Linear {
+  constructor(private add: Add, private mul: Mul) { }
+  public do(k: number, x: number, b: number) {
+    return this.add.do(this.mul.do(k, x), b);
+  }
+}
+
+@suite class TypeDITest {
+  constructor(public liner: Linear) { }
+  @test public "test linear function"() {
+    const k = 123;
+    const x = 63;
+    const b = 235;
+    assert.equal(this.liner.do(k, x, b), k * x + b,
+      `this.liner.do(${k}, ${x}, ${b}) should equal ${k} * ${x} + ${b}`);
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
         "removeComments": false,
         "preserveConstEnums": true,
         "sourceMap": true,
+        "emitDecoratorMetadata": true,
         "experimentalDecorators": true,
         "declaration": false,
         "listFiles": false


### PR DESCRIPTION
This features allows custom DI (Dependency Injection) systems to be registered and used by mocha-typescript.
Supports 'typedi' by requiring `mocha-typescript/di/typedi`.