### PR TITLE
fix: include di/typedi.js in the package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,13 @@
 
 
 
+<a name="1.1.17"></a>
+## [1.1.17](https://github.com/PanayotCankov/mocha-typescript/compare/v1.1.16...v1.1.17) (2018-06-13)
+
+
+### Bug Fixes
+
+* include di/typedi.js in the package ([0fc809e](https://github.com/PanayotCankov/mocha-typescript/commit/0fc809e))
+
+
+

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "index.js.map",
     "index.ts",
     "globals.d.ts",
-    "bin/watch.js"
+    "bin/watch.js",
+    "di/typedi.js"
   ]
 }


### PR DESCRIPTION
Support for dependency injection was shipped without the promised "mocha-typescript/di/typedi" module, adding the di/typedi.js in the package.