### PR TITLE
fix: Augment the new @types/mocha interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,13 @@
 
 
 <a name="1.1.17"></a>
-## [1.1.17](https://github.com/PanayotCankov/mocha-typescript/compare/v1.1.16...v1.1.17) (2018-06-13)
+## [1.1.17](https://github.com/PanayotCankov/mocha-typescript/compare/v1.1.16...v1.1.17) (2018-07-17)
 
 
 ### Bug Fixes
 
-* include di/typedi.js in the package ([0fc809e](https://github.com/PanayotCankov/mocha-typescript/commit/0fc809e))
+* Augment the new [@types](https://github.com/types)/mocha interfaces ([515b876](https://github.com/PanayotCankov/mocha-typescript/commit/515b876))
+* include di/typedi.js in the package ([a42a84b](https://github.com/PanayotCankov/mocha-typescript/commit/a42a84b))
 
 
 

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -46,6 +46,46 @@ declare namespace Mocha {
         skip(name: string, ... traits: MochaTypeScript.TestTrait[]): PropertyDecorator;
         skip(... traits: MochaTypeScript.TestTrait[]): PropertyDecorator;
     }
+    // @types/mocha v5.2.4
+    interface SuiteFunction {
+        (args: any): any;
+        (): ClassDecorator;
+        (name: string): ClassDecorator;
+        (name: string, ... traits: MochaTypeScript.SuiteTrait[]): ClassDecorator;
+        (trait: MochaTypeScript.SuiteTrait, ... traits:MochaTypeScript.SuiteTrait[]): ClassDecorator;
+    }
+    interface PendingSuiteFunction {
+        (args: any): any;
+        (): ClassDecorator;
+        (name: string): ClassDecorator;
+        (name: string, ... traits: MochaTypeScript.SuiteTrait[]): ClassDecorator;
+        (trait: MochaTypeScript.SuiteTrait, ... traits:MochaTypeScript.SuiteTrait[]): ClassDecorator;
+    }
+    interface ExclusiveSuiteFunction {
+        (args: any): any;
+        (): ClassDecorator;
+        (name: string): ClassDecorator;
+        (name: string, ... traits: MochaTypeScript.SuiteTrait[]): ClassDecorator;
+        (trait: MochaTypeScript.SuiteTrait, ... traits:MochaTypeScript.SuiteTrait[]): ClassDecorator;
+    }
+    interface TestFunction {
+        (target: Object, propertyKey: string | symbol): void;
+        (name: string): PropertyDecorator;
+        (name: string, ... traits: MochaTypeScript.TestTrait[]): PropertyDecorator;
+        (... traits: MochaTypeScript.TestTrait[]): PropertyDecorator;
+    }
+    interface PendingTestFunction {
+        (target: Object, propertyKey: string | symbol): void;
+        (name: string): PropertyDecorator;
+        (name: string, ... traits: MochaTypeScript.TestTrait[]): PropertyDecorator;
+        (... traits: MochaTypeScript.TestTrait[]): PropertyDecorator;
+    }
+    interface ExclusiveTestFunction {
+        (target: Object, propertyKey: string | symbol): void;
+        (name: string): PropertyDecorator;
+        (name: string, ... traits: MochaTypeScript.TestTrait[]): PropertyDecorator;
+        (... traits: MochaTypeScript.TestTrait[]): PropertyDecorator;
+    }
 }
 
 declare var skipOnError: MochaTypeScript.SuiteTrait;

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,6 +11,46 @@ declare namespace Mocha {
     export interface Suite {
         <TFunction extends Function>(target: TFunction): TFunction | void;
     }
+    // @types/mocha v5.2.4
+    interface SuiteFunction {
+        (args: any): any;
+        (): ClassDecorator;
+        (name: string): ClassDecorator;
+        (name: string, ... traits: MochaTypeScript.SuiteTrait[]): ClassDecorator;
+        (trait: MochaTypeScript.SuiteTrait, ... traits:MochaTypeScript.SuiteTrait[]): ClassDecorator;
+    }
+    interface PendingSuiteFunction {
+        (args: any): any;
+        (): ClassDecorator;
+        (name: string): ClassDecorator;
+        (name: string, ... traits: MochaTypeScript.SuiteTrait[]): ClassDecorator;
+        (trait: MochaTypeScript.SuiteTrait, ... traits:MochaTypeScript.SuiteTrait[]): ClassDecorator;
+    }
+    interface ExclusiveSuiteFunction {
+        (args: any): any;
+        (): ClassDecorator;
+        (name: string): ClassDecorator;
+        (name: string, ... traits: MochaTypeScript.SuiteTrait[]): ClassDecorator;
+        (trait: MochaTypeScript.SuiteTrait, ... traits:MochaTypeScript.SuiteTrait[]): ClassDecorator;
+    }
+    interface TestFunction {
+        (target: Object, propertyKey: string | symbol): void;
+        (name: string): PropertyDecorator;
+        (name: string, ... traits: MochaTypeScript.TestTrait[]): PropertyDecorator;
+        (... traits: MochaTypeScript.TestTrait[]): PropertyDecorator;
+    }
+    interface PendingTestFunction {
+        (target: Object, propertyKey: string | symbol): void;
+        (name: string): PropertyDecorator;
+        (name: string, ... traits: MochaTypeScript.TestTrait[]): PropertyDecorator;
+        (... traits: MochaTypeScript.TestTrait[]): PropertyDecorator;
+    }
+    interface ExclusiveTestFunction {
+        (target: Object, propertyKey: string | symbol): void;
+        (name: string): PropertyDecorator;
+        (name: string, ... traits: MochaTypeScript.TestTrait[]): PropertyDecorator;
+        (... traits: MochaTypeScript.TestTrait[]): PropertyDecorator;
+    }
 }
 
 declare namespace MochaTypeScript {


### PR DESCRIPTION
@types/mocha has been refactored and introduced new interfaces for
the 'suite' and 'test' functions. Now the new interfaces will
be augmented by mocha-typescript.