### PR TITLE
Refactor increase test coverage

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -30,7 +30,7 @@ const globalTestFunctions: TestFunctions = {
 };
 
 // key => Symbol("mocha-typescript:" + key)
-const nodeSymbol = (key) => "__mts_" + key;
+const nodeSymbol = (key): string => "__mts_" + key;
 
 const suiteSymbol = nodeSymbol("suite");
 const testNameSymbol = nodeSymbol("test");
@@ -64,26 +64,10 @@ interface SuiteProto {
 export type SuiteTrait = (this: Mocha.ISuiteCallbackContext, ctx: Mocha.ISuiteCallbackContext, ctor: SuiteCtor) => void;
 export type TestTrait = (this: Mocha.ITestCallbackContext, ctx: Mocha.ITestCallbackContext, instance: SuiteProto, method: Function) => void;
 
-const noname = (cb: ((done?: Function) => any), innerFunction?: Function): () => any => {
-    if (innerFunction && cb) {
-        let wrapperResult: any = function() {
-            return cb.apply(this, arguments);
-        };
-        if (cb.length === 1) {
-            // we need to handle the done callback explicitly in the definition for mocha to respect it correctly
-            wrapperResult = function(done) {
-                return cb.apply(this, arguments);
-            };
-        }
-
-        // wrap the toString method
-        wrapperResult.toString = () => {
-            return innerFunction && innerFunction.toString();
-        };
-        return wrapperResult;
-    } else {
-        return cb as any;
-    }
+const wrapNameAndToString = (cb: (done?: Function) => any, innerFunction: Function): () => any => {
+    cb.toString = () => innerFunction.toString();
+    Object.defineProperty(cb, "name", { value: innerFunction.name, writable: false });
+    return cb;
 };
 
 function applyDecorators(mocha: Mocha.IHookCallbackContext, ctorOrProto, method, instance) {
@@ -156,50 +140,50 @@ function suiteClassCallback(target: SuiteCtor, context: TestFunctions) {
         let beforeEachFunction: (() => any) | ((done: Function) => any);
         if (prototype.before) {
             if (isAsync(prototype.before)) {
-                beforeEachFunction = noname(function(this: Mocha.IHookCallbackContext, done: Function) {
+                beforeEachFunction = wrapNameAndToString(function(this: Mocha.IHookCallbackContext, done: Function) {
                     instance = getInstance(target);
                     applyDecorators(this, prototype, prototype.before, instance);
                     return prototype.before.call(instance, done);
-                });
+                }, prototype.before);
             } else {
-                beforeEachFunction = noname(function(this: Mocha.IHookCallbackContext) {
+                beforeEachFunction = wrapNameAndToString(function(this: Mocha.IHookCallbackContext) {
                     instance = getInstance(target);
                     applyDecorators(this, prototype, prototype.before, instance);
                     return prototype.before.call(instance);
-                });
+                }, prototype.before);
             }
         } else {
-            beforeEachFunction = noname(function(this: Mocha.IHookCallbackContext) {
+            beforeEachFunction = function(this: Mocha.IHookCallbackContext) {
                 instance = getInstance(target);
-            });
+            };
         }
         context.beforeEach(beforeEachFunction);
 
         let afterEachFunction: (() => any) | ((done: Function) => any);
         if (prototype.after) {
             if (isAsync(prototype.after)) {
-                afterEachFunction = noname(function(this: Mocha.IHookCallbackContext, done) {
+                afterEachFunction = wrapNameAndToString(function(this: Mocha.IHookCallbackContext, done) {
                     try {
                         applyDecorators(this, prototype, prototype.after, instance);
                         return prototype.after.call(instance, done);
                     } finally {
                         instance = undefined;
                     }
-                });
+                }, prototype.after);
             } else {
-                afterEachFunction = noname(function(this: Mocha.IHookCallbackContext) {
+                afterEachFunction = wrapNameAndToString(function(this: Mocha.IHookCallbackContext) {
                     try {
                         applyDecorators(this, prototype, prototype.after, instance);
                         return prototype.after.call(instance);
                     } finally {
                         instance = undefined;
                     }
-                });
+                }, prototype.after);
             }
         } else {
-            afterEachFunction = noname(function(this: Mocha.IHookCallbackContext) {
+            afterEachFunction = function(this: Mocha.IHookCallbackContext) {
                 instance = undefined;
-            });
+            };
         }
         context.afterEach(afterEachFunction);
 
@@ -259,17 +243,17 @@ function suiteClassCallback(target: SuiteCtor, context: TestFunctions) {
         function applyTestFunc(testFunc: Function, testName: string,
                                method: Function, callArgs: any[]) {
             if (isAsync(method)) {
-                testFunc(testName, noname(function(this: Mocha.ITestCallbackContext, done) {
+                testFunc(testName, wrapNameAndToString(function(this: Mocha.ITestCallbackContext, done) {
                   applyDecorators(this, prototype, method, instance);
                   applyTestTraits(this, instance, method);
                   return method.call(instance, done, ...callArgs);
-                }));
+                }, method));
             } else {
-                testFunc(testName, noname(function(this: Mocha.ITestCallbackContext) {
+                testFunc(testName, wrapNameAndToString(function(this: Mocha.ITestCallbackContext) {
                   applyDecorators(this, prototype, method, instance);
                   applyTestTraits(this, instance, method);
                   return method.call(instance, ...callArgs);
-                }));
+                }, method));
             }
         }
 
@@ -474,104 +458,54 @@ export function trait<T extends SuiteTrait | TestTrait>(arg: T): T {
     return arg;
 }
 
+function createNumericBuiltinTrait(traitSymbol: any, fn: (ctx: Mocha.ISuiteCallbackContext, value: number) => void) {
+    return function(value: number): MethodDecorator & PropertyDecorator & ClassDecorator & SuiteTrait & TestTrait {
+        return trait(function() {
+            if (arguments.length === 1) {
+                const target = arguments[0];
+                target[traitSymbol] = value;
+            } else if (arguments.length === 2 && typeof arguments[1] === "string" || typeof arguments[1] === "symbol") {
+                const target = arguments[0];
+                const property = arguments[1];
+                target[property][traitSymbol] = value;
+            } else if (arguments.length === 2) {
+                const context: Mocha.ISuiteCallbackContext = arguments[0];
+                const ctor = arguments[1];
+                fn(context, value);
+            } else if (arguments.length === 3) {
+                if (typeof arguments[2] === "function") {
+                    const context: Mocha.ITestCallbackContext = arguments[0];
+                    const instance = arguments[1];
+                    const method = arguments[2];
+                    fn(context, value);
+                } else if (typeof arguments[1] === "string" || typeof arguments[1] === "symbol") {
+                    const proto: Mocha.ITestCallbackContext = arguments[0];
+                    const prop = arguments[1];
+                    const descriptor = arguments[2];
+                    proto[prop][traitSymbol] = value;
+                }
+            }
+        });
+    };
+}
+
 /**
  * Set a test method execution time that is considered slow.
- * @param time The time in miliseconds.
+ * @param value The time in miliseconds.
  */
-export function slow(time: number): PropertyDecorator & ClassDecorator & SuiteTrait & TestTrait {
-    return trait(function() {
-        if (arguments.length === 1) {
-            const target = arguments[0];
-            target[slowSymbol] = time;
-        } else if (arguments.length === 2 && typeof arguments[1] === "string" || typeof arguments[1] === "symbol") {
-            const target = arguments[0];
-            const property = arguments[1];
-            target[property][slowSymbol] = time;
-        } else if (arguments.length === 2) {
-            const context: Mocha.ISuiteCallbackContext = arguments[0];
-            const ctor = arguments[1];
-            context.slow(time);
-        } else if (arguments.length === 3) {
-            if (typeof arguments[2] === "function") {
-                const context: Mocha.ITestCallbackContext = arguments[0];
-                const instance = arguments[1];
-                const method = arguments[2];
-                context.slow(time);
-            } else if (typeof arguments[1] === "string" || typeof arguments[1] === "symbol") {
-                const proto: Mocha.ITestCallbackContext = arguments[0];
-                const prop = arguments[1];
-                const descriptor = arguments[2];
-                proto[prop][slowSymbol] = time;
-            }
-        }
-    });
-}
+export const slow = createNumericBuiltinTrait(slowSymbol, (context, value) => context.slow(value));
 
 /**
  * Set a test method or suite timeout time.
- * @param time The time in miliseconds.
+ * @param value The time in miliseconds.
  */
-export function timeout(time: number): MethodDecorator & PropertyDecorator & ClassDecorator & SuiteTrait & TestTrait {
-    return trait(function() {
-        if (arguments.length === 1) {
-            const target = arguments[0];
-            target[timeoutSymbol] = time;
-        } else if (arguments.length === 2 && typeof arguments[1] === "string" || typeof arguments[1] === "symbol") {
-            const target = arguments[0];
-            const property = arguments[1];
-            target[property][timeoutSymbol] = time;
-        } else if (arguments.length === 2) {
-            const context: Mocha.ISuiteCallbackContext = arguments[0];
-            const ctor = arguments[1];
-            context.timeout(time);
-        } else if (arguments.length === 3) {
-            if (typeof arguments[2] === "function") {
-                const context: Mocha.ITestCallbackContext = arguments[0];
-                const instance = arguments[1];
-                const method = arguments[2];
-                context.timeout(time);
-            } else if (typeof arguments[1] === "string" || typeof arguments[1] === "symbol") {
-                const proto: Mocha.ITestCallbackContext = arguments[0];
-                const prop = arguments[1];
-                const descriptor = arguments[2];
-                proto[prop][timeoutSymbol] = time;
-            }
-        }
-    });
-}
+export const timeout = createNumericBuiltinTrait(timeoutSymbol, (context, value) => context.timeout(value));
 
 /**
  * Set a test method or site retries count.
- * @param count The number of retries to attempt when running the test.
+ * @param value The number of retries to attempt when running the test.
  */
-export function retries(count: number): MethodDecorator & PropertyDecorator & ClassDecorator & SuiteTrait & TestTrait {
-    return trait(function() {
-        if (arguments.length === 1) {
-            const target = arguments[0];
-            target[retriesSymbol] = count;
-        } else if (arguments.length === 2 && typeof arguments[1] === "string" || typeof arguments[1] === "symbol") {
-            const target = arguments[0];
-            const property = arguments[1];
-            target[property][retriesSymbol] = count;
-        } else if (arguments.length === 2) {
-            const context: Mocha.ISuiteCallbackContext = arguments[0];
-            const ctor = arguments[1];
-            context.retries(count);
-        } else if (arguments.length === 3) {
-            if (typeof arguments[2] === "function") {
-                const context: Mocha.ITestCallbackContext = arguments[0];
-                const instance = arguments[1];
-                const method = arguments[2];
-                context.retries(count);
-            } else if (typeof arguments[1] === "string" || typeof arguments[1] === "symbol") {
-                const proto: Mocha.ITestCallbackContext = arguments[0];
-                const prop = arguments[1];
-                const descriptor = arguments[2];
-                proto[prop][retriesSymbol] = count;
-            }
-        }
-    });
-}
+export const retries = createNumericBuiltinTrait(retriesSymbol, (context, value) => context.retries(value));
 
 export const skipOnError: SuiteTrait = trait(function(ctx, ctor) {
     ctx.beforeEach(function() {
@@ -586,44 +520,36 @@ export const skipOnError: SuiteTrait = trait(function(ctx, ctor) {
     });
 });
 
+function createExecutionModifier(executionSymbol: any): <TFunction extends Function>(target: Object | TFunction, propertyKey?: string | symbol) => void {
+    return function <TFunction extends Function>(target: Object | TFunction, propertyKey?: string | symbol): void {
+        if (arguments.length === 1) {
+            target[executionSymbol] = true;
+        } else {
+            target[propertyKey][executionSymbol] = true;
+        }
+    };
+}
+
 /**
  * Mart a test or suite as pending.
  *  - Used as `@suite @pending class` is `describe.skip("name", ...);`.
  *  - Used as `@test @pending method` is `it("name");`
  */
-export function pending<TFunction extends Function>(target: Object | TFunction, propertyKey?: string | symbol): void {
-    if (arguments.length === 1) {
-        target[pendingSymbol] = true;
-    } else {
-        target[propertyKey][pendingSymbol] = true;
-    }
-}
+export const pending = createExecutionModifier(pendingSymbol);
 
 /**
  * Mark a test or suite as the only one to execute.
  *  - Used as `@suite @only class` is `describe.only("name", ...)`.
  *  - Used as `@test @only method` is `it.only("name", ...)`.
  */
-export function only<TFunction extends Function>(target: Object, propertyKey?: string | symbol): void {
-    if (arguments.length === 1) {
-        target[onlySymbol] = true;
-    } else {
-        target[propertyKey][onlySymbol] = true;
-    }
-}
+export const only = createExecutionModifier(onlySymbol);
 
 /**
  * Mark a test or suite to skip.
  *  - Used as `@suite @skip class` is `describe.skip("name", ...);`.
  *  - Used as `@test @skip method` is `it.skip("name")`.
  */
-export function skip<TFunction extends Function>(target: Object | TFunction, propertyKey?: string | symbol): void {
-    if (arguments.length === 1) {
-        target[onlySymbol] = true;
-    } else {
-        target[propertyKey][skipSymbol] = true;
-    }
-}
+export const skip = createExecutionModifier(skipSymbol);
 
 /**
  * Mark a method as test. Use the method name as test name.

--- a/package.json
+++ b/package.json
@@ -65,10 +65,10 @@
   ],
   "nyc": {
     "check-coverage": true,
-    "lines": 80,
-    "statements": 80,
-    "functions": 80,
-    "branches": 80,
+    "lines": 95,
+    "statements": 85,
+    "functions": 95,
+    "branches": 95,
     "include": [
       "**/*.js"
     ],

--- a/test/it/AsyncSuiteIT.ts
+++ b/test/it/AsyncSuiteIT.ts
@@ -1,0 +1,24 @@
+import { suite, test } from "../../index";
+
+@suite()
+class AsyncSuite {
+    static before(done) {
+        setTimeout(done, 1);
+    }
+
+    before(done) {
+        setTimeout(done, 1);
+    }
+
+    @test test(done) {
+        setTimeout(done, 1);
+    }
+
+    after(done) {
+        setTimeout(done, 1);
+    }
+
+    static after(done) {
+        setTimeout(done, 1);
+    }
+}

--- a/test/it/OnlySuiteIT.ts
+++ b/test/it/OnlySuiteIT.ts
@@ -8,6 +8,10 @@ class OnlySuiteIT extends AbstractSuiteITBase {
   @params({ target: "es6", fixture: "only.suite" })
   @params({ target: "es5", fixture: "only.v2.suite" })
   @params({ target: "es6", fixture: "only.v2.suite" })
+  @params({ target: "es5", fixture: "only.test.suite" })
+  @params({ target: "es6", fixture: "only.test.suite" })
+  @params({ target: "es5", fixture: "only.tbdd.suite" })
+  @params({ target: "es6", fixture: "only.tbdd.suite" })
   @params.naming(({ target, fixture }: SuiteTestParams) => `${fixture} ${target}`)
   runTest(params: SuiteTestParams) {
 

--- a/test/it/fixtures/only.tbdd.suite.expected.txt
+++ b/test/it/fixtures/only.tbdd.suite.expected.txt
@@ -1,0 +1,8 @@
+
+  vanila tdd suite
+    ✓ only
+
+  vanila bdd suite
+    ✓ only
+
+  2 passing

--- a/test/it/fixtures/only.tbdd.suite.ts
+++ b/test/it/fixtures/only.tbdd.suite.ts
@@ -1,0 +1,11 @@
+import { suite, test } from "../../../index";
+
+suite("vanila tdd suite", () => {
+    test("vanila test", () => {});
+    test.only("only", () => {});
+});
+
+describe("vanila bdd suite", () => {
+    it("vanila test", () => {});
+    it.only("only", () => {});
+});

--- a/test/it/fixtures/only.test.suite.expected.txt
+++ b/test/it/fixtures/only.test.suite.expected.txt
@@ -1,0 +1,5 @@
+
+  Suite1
+    ✓ test2
+
+  1 passing

--- a/test/it/fixtures/only.test.suite.ts
+++ b/test/it/fixtures/only.test.suite.ts
@@ -1,0 +1,6 @@
+import { only, pending, skip, slow, suite, test, timeout } from "../../../index";
+
+@suite class Suite1 {
+    @test public test1() {}
+    @test.only public test2() {}
+}

--- a/test/it/fixtures/test.suite.expected.txt
+++ b/test/it/fixtures/test.suite.expected.txt
@@ -29,7 +29,7 @@
 
   FailingAsyncLifeCycle
     ✓ one
-    4) "after each" hook for "one"
+    4) "after each" hook: after for "one"
     5) "after all" hook
 
   PassingAsyncLifeCycle
@@ -70,11 +70,11 @@
     ✓ third fast
 
   SlowBefore
-    8) "before each" hook for "will fail for slow before"
+    8) "before each" hook: before for "will fail for slow before"
 
   SlowAfter
     ✓ will fail for slow after
-    9) "after each" hook for "will fail for slow after"
+    9) "after each" hook: after for "will fail for slow after"
 
   outer suite
     TestClass
@@ -98,7 +98,7 @@
      Error: Ooopsss...
 
   4) FailingAsyncLifeCycle
-       "after each" hook for "one":
+       "after each" hook: after for "one":
      Error: Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.
 
   5) FailingAsyncLifeCycle
@@ -114,10 +114,10 @@
      Error: Timeout of 10ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.
 
   8) SlowBefore
-       "before each" hook for "will fail for slow before":
+       "before each" hook: before for "will fail for slow before":
      Error: Timeout of 10ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.
 
   9) SlowAfter
-       "after each" hook for "will fail for slow after":
+       "after each" hook: after for "will fail for slow after":
      Error: Timeout of 10ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.
 


### PR DESCRIPTION
This is based on refactor-reusable-code.

- existing branch expressions have been simplified
- add missing test for ``@test.only``, ``it.only()`` and ``test.only()`` to OnlySuiteIT
- remove tests for symbols as typescript does not support them for properties anyway, propertyKeys must always be simple strings
