### PR TITLE
fix: Use new @types/mocha APIs and fix tslint deprecation erros

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -64,10 +64,10 @@ declare namespace MochaTypeScript {
         new(): any;
     }
     export interface SuiteTrait {
-        (this: Mocha.ISuiteCallbackContext, ctx: Mocha.ISuiteCallbackContext, ctor: Function): void;
+        (this: Mocha.Suite, ctx: Mocha.Suite, ctor: Function): void;
     }
     export interface TestTrait {
-        (this: Mocha.ITestCallbackContext, ctx: Mocha.ITestCallbackContext, instance: Object, method: Function): void;
+        (this: Mocha.Context, ctx: Mocha.Context, instance: Object, method: Function): void;
     }
 
     export interface IContextDefinition {
@@ -123,11 +123,11 @@ declare namespace MochaTypeScript {
 }
 
 declare module "mocha-typescript" {
-    export const suite: Mocha.IContextDefinition & MochaTypeScript.IContextDefinition;
-    export const test: Mocha.ITestDefinition & MochaTypeScript.ITestDefinition;
+    export const suite: Mocha.SuiteFunction & MochaTypeScript.IContextDefinition;
+    export const test: Mocha.TestFunction & MochaTypeScript.ITestDefinition;
 
-    export const describe: Mocha.IContextDefinition & MochaTypeScript.IContextDefinition;
-    export const it: Mocha.ITestDefinition & MochaTypeScript.ITestDefinition;
+    export const describe: Mocha.SuiteFunction & MochaTypeScript.IContextDefinition;
+    export const it: Mocha.TestFunction & MochaTypeScript.ITestDefinition;
 
     export function slow(time: number): PropertyDecorator & ClassDecorator & MochaTypeScript.SuiteTrait & MochaTypeScript.TestTrait;
     export function timeout(time: number): PropertyDecorator & ClassDecorator & MochaTypeScript.SuiteTrait & MochaTypeScript.TestTrait;

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "@types/mocha": "^5.2.0",
     "chalk": "^2.4.1",
     "cross-spawn": "^6.0.5",
     "yargs": "^11.0.0"
@@ -41,6 +40,7 @@
   "devDependencies": {
     "@types/chai": "^4.1.3",
     "@types/cross-spawn": "^6.0.0",
+    "@types/mocha": "^5.2.5",
     "@types/node": "^10.1.4",
     "chai": "^4.1.2",
     "conventional-changelog-cli": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -45,14 +45,14 @@
     "chai": "^4.1.2",
     "conventional-changelog-cli": "^2.0.1",
     "mocha": "^5.2.0",
+    "nyc": "^12.0.2",
+    "reflect-metadata": "^0.1.12",
     "rimraf": "^2.6.2",
     "source-map-support": "^0.5.6",
-    "tslint": "^5.10.0",
-    "typescript": "^2.9.1",
-    "reflect-metadata": "^0.1.12",
+    "ts-node": "^6.1.0",
+    "tslint": "^5.11.0",
     "typedi": "^0.7.3",
-    "nyc": "^12.0.2",
-    "ts-node": "^6.1.0"
+    "typescript": "^2.9.1"
   },
   "files": [
     "index.js",

--- a/test/it/fixtures/abstract.inheritance.override1.suite.expected.txt
+++ b/test/it/fixtures/abstract.inheritance.override1.suite.expected.txt
@@ -5,4 +5,4 @@
   1 failing
   1) ConcreteTest
        inherited test from AbstractTestBase:
-     AssertionError: assert.fail()
+     AssertionError: derived suites must implement this

--- a/test/it/fixtures/context.suite.ts
+++ b/test/it/fixtures/context.suite.ts
@@ -15,10 +15,10 @@ import { context, only, pending, skip, slow, suite, test, timeout } from "../../
     @suite(`OAuth ${title}`) class OAuthTest {
 
         // Get the mocha context in for instance before and after (before/after each) and test methods.
-        @context public mocha: mocha.Context & mocha.Context;
+        @context public mocha: mocha.Context;
 
         // Get the mocha context for static before and after.
-        @context public static mocha: mocha.Context & mocha.Context;
+        @context public static mocha: mocha.Context;
 
         @test public async "Request token"() {
             // return (await request(url)).responce.headers.token;

--- a/test/it/fixtures/context.suite.ts
+++ b/test/it/fixtures/context.suite.ts
@@ -15,10 +15,10 @@ import { context, only, pending, skip, slow, suite, test, timeout } from "../../
     @suite(`OAuth ${title}`) class OAuthTest {
 
         // Get the mocha context in for instance before and after (before/after each) and test methods.
-        @context public mocha: mocha.IBeforeAndAfterContext & mocha.IHookCallbackContext;
+        @context public mocha: mocha.Context & mocha.Context;
 
         // Get the mocha context for static before and after.
-        @context public static mocha: mocha.IBeforeAndAfterContext & mocha.IHookCallbackContext;
+        @context public static mocha: mocha.Context & mocha.Context;
 
         @test public async "Request token"() {
             // return (await request(url)).responce.headers.token;

--- a/tslint.json
+++ b/tslint.json
@@ -15,7 +15,8 @@
         "ban-types": false,
         "no-shadowed-variable": false,
         "forin": false,
-        "member-ordering": false
+        "member-ordering": false,
+        "deprecation": true
     },
     "rulesDirectory": []
 }


### PR DESCRIPTION
The mocha-typescrip use deprecated @types/mocha APIs.
It will use the more recent APIs now, it may require you to update @types/mocha.