### PR TITLE
fix #120: get rid of redundant declarations in the custom ui

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -571,81 +571,6 @@ export function context(target: Object, propertyKey: string | symbol): void {
     target[contextSymbol] = propertyKey;
 }
 
-/**
- * Rip-off the TDD and BDD at: mocha/lib/interfaces/tdd.js and mocha/lib/interfaces/bdd.js
- * Augmented the suite and test for the mocha-typescript decorators.
- */
-function tsdd(suite) {
-    const suites = [suite];
-
-    suite.on("pre-require", function(context, file, mocha) {
-        const common = Common(suites, context, mocha);
-
-        context.before = common.before;
-        context.after = common.after;
-        context.beforeEach = common.beforeEach;
-        context.afterEach = common.afterEach;
-
-        /* istanbul ignore next */
-        context.run = mocha.options.delay && common.runWithSuite(suite);
-
-        // Copy of bdd
-        context.describe = context.context = function(title, fn) {
-            return common.suite.create({
-                title,
-                file,
-                fn,
-            });
-        };
-        context.xdescribe = context.xcontext = context.describe.skip = function(title, fn) {
-            return common.suite.skip({
-                title,
-                file,
-                fn,
-            });
-        };
-        context.describe.only = function(title, fn) {
-            return common.suite.only({
-                title,
-                file,
-                fn,
-            });
-        };
-        context.it = context.specify = function(title, fn) {
-            const suite = suites[0];
-            if (suite.isPending()) {
-                fn = null;
-            }
-            const test = new Test(title, fn);
-            test.file = file;
-            suite.addTest(test);
-            return test;
-        };
-        context.it.only = function(title, fn) {
-            return common.test.only(mocha, context.it(title, fn));
-        };
-        context.xit = context.xspecify = context.it.skip = function(title) {
-            context.it(title);
-        };
-
-        /* istanbul ignore next */
-        context.it.retries = function(n) {
-            context.retries(n);
-        };
-
-        context.suite = makeSuiteObject(context);
-        context.params = makeParamsObject(context);
-        context.test = makeTestObject(context);
-
-        context.test.retries = common.test.retries;
-
-        context.timeout = timeout;
-        context.slow = slow;
-        context.retries = retries;
-        context.skipOnError = skipOnError;
-    });
-}
-
 interface TestClass<T> {
     new(...args: any[]): T;
     prototype: T;
@@ -681,5 +606,13 @@ export function registerDI(instantiator: DependencyInjectionSystem) {
     }
 }
 
-module.exports = Object.assign(tsdd, exports);
-(Mocha as any).interfaces["mocha-typescript"] = tsdd;
+/**
+ * Dummy Mocha Custom Test UI.
+ */
+function mochatypescriptui() {
+
+}
+
+// for Mocha we need to make the root export a function so that it will recognise it as a custom test ui
+module.exports = Object.assign(mochatypescriptui, exports);
+Mocha.interfaces["mocha-typescript"] = mochatypescriptui;

--- a/package.json
+++ b/package.json
@@ -38,11 +38,11 @@
     "yargs": "^11.0.0"
   },
   "devDependencies": {
-    "@types/chai": "^4.1.3",
+    "@types/chai": "^4.1.7",
     "@types/cross-spawn": "^6.0.0",
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.1.4",
-    "chai": "^4.1.2",
+    "chai": "^4.2.0",
     "conventional-changelog-cli": "^2.0.1",
     "mocha": "^5.2.0",
     "nyc": "^12.0.2",
@@ -52,7 +52,7 @@
     "ts-node": "^6.1.0",
     "tslint": "^5.11.0",
     "typedi": "^0.7.3",
-    "typescript": "^2.9.1"
+    "typescript": "^3.2.1"
   },
   "files": [
     "index.js",

--- a/test/it/AsyncSuiteIT.ts
+++ b/test/it/AsyncSuiteIT.ts
@@ -1,4 +1,4 @@
-import { params, suite } from "../../index";
+import { params, suite, timeout } from "../../index";
 import { AbstractSuiteITBase, SuiteTestParams } from "./AbstractSuiteITBase";
 
 @suite(timeout(10000))

--- a/test/it/ContextSuiteIT.ts
+++ b/test/it/ContextSuiteIT.ts
@@ -1,4 +1,4 @@
-import { params, suite } from "../../index";
+import { params, suite, timeout } from "../../index";
 import { AbstractSuiteITBase, SuiteTestParams } from "./AbstractSuiteITBase";
 
 @suite(timeout(10000))

--- a/test/it/CustomUiPackageIT.ts
+++ b/test/it/CustomUiPackageIT.ts
@@ -1,4 +1,4 @@
-import { params, suite } from "../../index";
+import { params, skip, slow, suite, timeout } from "../../index";
 import { AbstractPackageITBase, PackageTestParams } from "./AbstractPackageITBase";
 
 @suite(timeout(90000), slow(10000))

--- a/test/it/DependencyInjectionSuiteIT.ts
+++ b/test/it/DependencyInjectionSuiteIT.ts
@@ -1,4 +1,4 @@
-import { params, suite } from "../../index";
+import { params, suite, timeout } from "../../index";
 import { AbstractSuiteITBase, SuiteTestParams } from "./AbstractSuiteITBase";
 
 @suite(timeout(10000))

--- a/test/it/InheritanceSuiteIT.ts
+++ b/test/it/InheritanceSuiteIT.ts
@@ -1,4 +1,4 @@
-import { params, suite } from "../../index";
+import { params, suite, timeout } from "../../index";
 import { AbstractSuiteITBase, SuiteTestParams } from "./AbstractSuiteITBase";
 
 @suite(timeout(10000))

--- a/test/it/ModuleUsagePackageIT.ts
+++ b/test/it/ModuleUsagePackageIT.ts
@@ -1,4 +1,4 @@
-import { params, suite } from "../../index";
+import { params, slow, suite, timeout } from "../../index";
 import { AbstractPackageITBase, PackageTestParams } from "./AbstractPackageITBase";
 
 @suite(timeout(90000), slow(10000))

--- a/test/it/OnlySuiteIT.ts
+++ b/test/it/OnlySuiteIT.ts
@@ -1,4 +1,4 @@
-import { params, suite } from "../../index";
+import { params, suite, timeout } from "../../index";
 import { AbstractSuiteITBase, SuiteTestParams } from "./AbstractSuiteITBase";
 
 @suite(timeout(10000))

--- a/test/it/ParamsSuiteIT.ts
+++ b/test/it/ParamsSuiteIT.ts
@@ -1,4 +1,4 @@
-import { params, suite } from "../../index";
+import { params, suite, timeout } from "../../index";
 import { AbstractSuiteITBase, SuiteTestParams } from "./AbstractSuiteITBase";
 
 @suite(timeout(10000))

--- a/test/it/PendingSuiteIT.ts
+++ b/test/it/PendingSuiteIT.ts
@@ -1,4 +1,4 @@
-import { params, suite } from "../../index";
+import { params, suite, timeout } from "../../index";
 import { AbstractSuiteITBase, SuiteTestParams } from "./AbstractSuiteITBase";
 
 @suite(timeout(10000))

--- a/test/it/RetriesSuiteIT.ts
+++ b/test/it/RetriesSuiteIT.ts
@@ -1,4 +1,4 @@
-import { params, suite } from "../../index";
+import { params, suite, timeout } from "../../index";
 import { AbstractSuiteITBase, SuiteTestParams } from "./AbstractSuiteITBase";
 
 @suite(timeout(10000))

--- a/test/it/SettingUpPackageIT.ts
+++ b/test/it/SettingUpPackageIT.ts
@@ -1,4 +1,4 @@
-import { params, suite } from "../../index";
+import { params, slow, suite, timeout } from "../../index";
 import { AbstractPackageITBase, PackageTestParams } from "./AbstractPackageITBase";
 
 @suite(timeout(90000), slow(10000))

--- a/test/it/SkipSuiteIT.ts
+++ b/test/it/SkipSuiteIT.ts
@@ -1,4 +1,4 @@
-import { params, suite } from "../../index";
+import { params, suite, timeout } from "../../index";
 import { AbstractSuiteITBase, SuiteTestParams } from "./AbstractSuiteITBase";
 
 @suite(timeout(10000))

--- a/test/it/StandardFeaturesSuiteIT.ts
+++ b/test/it/StandardFeaturesSuiteIT.ts
@@ -1,4 +1,4 @@
-import { params, suite } from "../../index";
+import { params, suite, timeout } from "../../index";
 import { AbstractSuiteITBase, SuiteTestParams } from "./AbstractSuiteITBase";
 
 @suite(timeout(10000))

--- a/test/it/fixtures/packages/custom-ui/package.json
+++ b/test/it/fixtures/packages/custom-ui/package.json
@@ -9,9 +9,9 @@
   "author": "",
   "license": "Apache-2.0",
   "devDependencies": {
-    "chai": "^4.0.2",
+    "chai": "*",
     "mocha": "*",
-    "source-map-support": "^0.4.14",
-    "typescript": "^2.4.0"
+    "source-map-support": "*",
+    "typescript": "*"
   }
 }

--- a/test/it/fixtures/packages/custom-ui/test/test.ts
+++ b/test/it/fixtures/packages/custom-ui/test/test.ts
@@ -1,5 +1,5 @@
-/// <reference path="../node_modules/mocha-typescript/globals.d.ts" />
 import { assert } from "chai";
+import { retries, skipOnError, suite, test, timeout} from 'mocha-typescript';
 
 @suite class Suite1 {
     @test "one"() {
@@ -20,7 +20,7 @@ import { assert } from "chai";
         });
     }
     @test.skip "five"() {
-        
+
     }
 }
 

--- a/test/it/fixtures/packages/setting-up/test/tests.ts
+++ b/test/it/fixtures/packages/setting-up/test/tests.ts
@@ -1,5 +1,4 @@
-// Reference mocha-typescript's global definitions:
-/// <reference path="../node_modules/mocha-typescript/globals.d.ts" />
+import { slow, suite, test, timeout } from "mocha-typescript";
 
 @suite(timeout(3000), slow(1000))
 class Hello {

--- a/test/it/util.ts
+++ b/test/it/util.ts
@@ -6,7 +6,6 @@ function assertContent(actualStr: string, expectedStr: string) {
   const actual: string[] = actualStr.split("\n");
   const expected: string[] = expectedStr.split("\n");
 
-  assert.equal(actual.length, expected.length, "actual and expected differ in length");
   for (let i = 0; i < expected.length; i++) {
     const expectedLine = expected[i].trim();
     const actualLine = actual[i].trim();
@@ -14,6 +13,7 @@ function assertContent(actualStr: string, expectedStr: string) {
       "Unexpected output on line '" + i + "'. Expected: '" +
       expectedLine + "' to be contained in '" + actualLine + "'");
   }
+  assert.equal(actual.length, expected.length, "actual and expected differ in length");
 }
 
 export function assertOutput(actual: string, filePath: string) {
@@ -61,6 +61,8 @@ export function cleanup(str: string, eliminateAllEmptyLines = false): string {
   // somehow nyc seems to inject these into the output, at least they only occur in that context
   // we might want to further investigate this in the future
   result = result.replace(/^import.*$/mg, ELIMINATE_LINE);
+  // this is a new one: const globalTestFunctions: TestFunctions = {
+  result = result.replace(/^const globalTestFunctions: TestFunctions = .*$/mg, ELIMINATE_LINE);
 
   return trimEmptyLines(result, eliminateAllEmptyLines);
 }


### PR DESCRIPTION
This removes all suite.on() declarations as they are redundant and will also lead to malfunctioning suites when using the declarative API.

However, this will require users of the OOP api to explicitly import timeout, slow and so on.

But I am fine with that.

@pana-cc What do you think?
