### PR TITLE
fix: expose params constant from exported typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -115,6 +115,15 @@ declare namespace MochaTypeScript {
         new(...args: any[]): T;
         prototype: T;
     }
+    
+    export interface IParamsDefiniton {
+        (params: any, name?: string): PropertyDecorator;
+
+        skip(params: any, name?: string): PropertyDecorator;
+        only(params: any, name?: string): PropertyDecorator;
+        pending(params: any, name?: string): PropertyDecorator;
+        naming(nameForParameters: (parameters: any) => string): PropertyDecorator;
+    }
 
     export interface DependencyInjectionSystem {
         handles<T>(cls: TestClass<T>): boolean;
@@ -125,6 +134,8 @@ declare namespace MochaTypeScript {
 declare module "mocha-typescript" {
     export const suite: Mocha.SuiteFunction & MochaTypeScript.IContextDefinition;
     export const test: Mocha.TestFunction & MochaTypeScript.ITestDefinition;
+
+    export const params: MochaTypeScript.IParamsDefiniton;
 
     export const describe: Mocha.SuiteFunction & MochaTypeScript.IContextDefinition;
     export const it: Mocha.TestFunction & MochaTypeScript.ITestDefinition;


### PR DESCRIPTION
Params is a helpful, well tested feature of this library. This change allows it to be imported alongside test and suite for use in user-land projects. With this change, `import { params, suite, test } from 'mocha-typescript';` is now possible, where previously this would have required a @ts-ignore